### PR TITLE
Remove unused references to safeguard performance

### DIFF
--- a/fetchCSVs_1.js
+++ b/fetchCSVs_1.js
@@ -20,6 +20,8 @@ getCSV(
 );
 
 alterState(state => {
+  // NOTE: Remove unused prior references.
+  state.references = [];
   // NOTE: Choose countries to include here.
   // WARNING: The longer this list becomes, the longer the execution will take.
   state.selectedCountries = [

--- a/fetchCSVs_2.js
+++ b/fetchCSVs_2.js
@@ -20,6 +20,8 @@ getCSV(
 );
 
 alterState(state => {
+  // NOTE: Remove unused prior references.
+  state.references = [];
   // NOTE: Choose countries to include here.
   // WARNING: The longer this list becomes, the longer the execution will take.
   state.selectedCountries = [

--- a/fetchCSVs_3.js
+++ b/fetchCSVs_3.js
@@ -20,6 +20,8 @@ getCSV(
 );
 
 alterState(state => {
+  // NOTE: Remove unused prior references.
+  state.references = [];
   // NOTE: Choose countries to include here.
   // WARNING: The longer this list becomes, the longer the execution will take.
   state.selectedCountries = [


### PR DESCRIPTION
As each job run should be treated as a totally new event, we can safely remove the array of `references` inside `state` which will otherwise continue to grow (`state.references.push(...)`) with each subsequent run. This could lead to performance issues in the future.

Safe to merge as there's no impact on the current job.